### PR TITLE
chore: add env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# NextAuth Configuration
+NEXTAUTH_URL="http://localhost:3000"
+# API Configuration
+NEXT_PUBLIC_API_URL="http://localhost:8080/"
+
+NEXTAUTH_SECRET="my_something_is_not_secret_at_all"
+# Google OAuth
+GOOGLE_CLIENT_ID="your_google_client_id"
+GOOGLE_CLIENT_SECRET="your_google_client_secret"
+# GitHub OAuth
+GITHUB_CLIENT_ID="your_github_client_id"
+GITHUB_CLIENT_SECRET="your_github_client_secret"
+# Facebook OAuth
+FACEBOOK_CLIENT_ID="your_facebook_client_id"
+FACEBOOK_CLIENT_SECRET="your_facebook_client_secret"

--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,7 @@ yarn-error.log*
 pnpm-lock.yaml
 
 # env files (can opt-in for committing if needed)
-.env*
+.env
 
 # vercel
 .vercel


### PR DESCRIPTION
This pull request adds an example environment configuration file to help set up authentication and API endpoints for local development. The file provides placeholders for NextAuth, API URL, and OAuth credentials for Google, GitHub, and Facebook.

- Environment configuration:
  * Added `.env.example` file with example variables for `NEXTAUTH_URL`, `NEXT_PUBLIC_API_URL`, and `NEXTAUTH_SECRET`.

- OAuth provider setup:
  * Included placeholder credentials for Google, GitHub, and Facebook OAuth integrations.