### PR TITLE
fix: remove unneccessary slash

### DIFF
--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -4,7 +4,7 @@ import ResponseError from "@/lib/data/response_error";
 export async function GET(req: Request) {
   try {
     const headers = req.headers;
-    const response = await fetch(`${BASE_URL}/api/users/profile`, {
+    const response = await fetch(`${BASE_URL}api/users/profile`, {
       method: "GET",
       headers,
     });

--- a/src/app/api/review/route.ts
+++ b/src/app/api/review/route.ts
@@ -4,7 +4,7 @@ import ResponseError from "@/lib/data/response_error";
 export async function POST(req: Request) {
   const headers = req.headers;
   const reviewData = await req.json();
-  const newReview = await fetch(`${BASE_URL}/api/reviews/trip`, {
+  const newReview = await fetch(`${BASE_URL}api/reviews/trip`, {
     method: "POST",
     headers,
     body: JSON.stringify(reviewData),


### PR DESCRIPTION
This pull request fixes the construction of backend API URLs in the `profile` and `review` API route handlers by removing an extra slash, ensuring correct endpoint requests.

API endpoint URL corrections:

* Fixed the URL in `src/app/api/profile/route.ts` by removing the extra slash after `BASE_URL` when fetching the user profile.
* Fixed the URL in `src/app/api/review/route.ts` by removing the extra slash after `BASE_URL` when posting a new trip review.