### PR TITLE
fix: mistaken use hook naming for a api function call

### DIFF
--- a/src/components/custom/booking/BookingInteractiveSection.tsx
+++ b/src/components/custom/booking/BookingInteractiveSection.tsx
@@ -11,7 +11,7 @@ import { Button } from "@/components/ui/button";
 import { DiscountInfo } from "@/lib/data/discount";
 import { useTranslations } from "next-intl";
 import PointsSection from "./PointsSession";
-import { getScore, usePoints } from "@/lib/data/score";
+import { getScore, makeUsePoints } from "@/lib/data/score";
 
 
 interface BookingData {
@@ -208,7 +208,7 @@ export default function BookingInteractiveSection({
       // Nếu user có dùng điểm thì gọi API trừ điểm
       if (usedPoints > 0 && session?.user?.accessToken) {
         try {
-          const pointResponse = await usePoints(
+          const pointResponse = await makeUsePoints(
             {
               bookingId: bookingId,
               pointsToUse: usedPoints,

--- a/src/lib/data/score.ts
+++ b/src/lib/data/score.ts
@@ -33,7 +33,7 @@ const getScore = async (): Promise<ScoreInfo> => {
   }
 };
 
-const usePoints = async (
+const makeUsePoints = async (
   request: UsePointsRequest,
   token: string
 ): Promise<ApiResponse<ScoreInfo>> => {
@@ -54,4 +54,4 @@ const usePoints = async (
   }
 };
 
-export { getScore, usePoints };
+export { getScore, makeUsePoints };


### PR DESCRIPTION
This pull request refactors the points usage API in the booking flow by renaming the `usePoints` function to `makeUsePoints` for clarity and consistency. The change is applied both in the API implementation and where it is used in the booking component.

**API refactor:**

* Renamed the `usePoints` function to `makeUsePoints` in `src/lib/data/score.ts` and updated the export accordingly. [[1]](diffhunk://#diff-814365199341be953fba504b6511df7e893ce752dd8843e5861455960cd2a82bL36-R36) [[2]](diffhunk://#diff-814365199341be953fba504b6511df7e893ce752dd8843e5861455960cd2a82bL57-R57)

**Component updates:**

* Updated imports and usage of the points API in `BookingInteractiveSection.tsx` to use `makeUsePoints` instead of `usePoints`. [[1]](diffhunk://#diff-3a493a22f78e3b246bf7a7d3a4487cbad3a52dd2adab6df98dd7076f1eb1992cL14-R14) [[2]](diffhunk://#diff-3a493a22f78e3b246bf7a7d3a4487cbad3a52dd2adab6df98dd7076f1eb1992cL211-R211)