### PR TITLE
fix: duplicate cancel button

### DIFF
--- a/src/components/custom/my_tickets/ticket_card.tsx
+++ b/src/components/custom/my_tickets/ticket_card.tsx
@@ -309,7 +309,7 @@ export const TicketCard = ({
             className="flex-1 h-8 text-xs"
           >
             {t("MyTickets.details")}
-          </Button>{" "}
+          </Button>
           {(booking.status === "confirmed" || booking.status === "pending") &&
             !isPast && (
               <Button
@@ -321,19 +321,10 @@ export const TicketCard = ({
               >
                 {isCancelling
                   ? t("MyTickets.cancelling")
-                  : t("MyTickets.cancel")}{" "}
+                  : t("MyTickets.cancel")}
                 {/* Text động */}
               </Button>
             )}
-          {booking.status === "confirmed" && !isPast && (
-            <Button
-              variant="destructive"
-              size="sm"
-              className="h-8 px-3 text-xs"
-            >
-              Hủy
-            </Button>
-          )}
           {booking.status === "completed" && (
             <>
               <Button


### PR DESCRIPTION
This pull request makes minor improvements to the `TicketCard` component by cleaning up unnecessary whitespace and removing unused code related to the cancel button.

- Code cleanup:
  * Removed unnecessary whitespace from JSX elements, improving code readability. [[1]](diffhunk://#diff-9184168017db90bcf9b32a33d6cb84a9256fbc921070dcb485ad09feda1206efL312-R312) [[2]](diffhunk://#diff-9184168017db90bcf9b32a33d6cb84a9256fbc921070dcb485ad09feda1206efL324-L336)

- Dead code removal:
  * Removed an unused "Hủy" (Cancel) button that was previously rendered for confirmed bookings, which is now redundant due to existing cancellation logic.